### PR TITLE
Added BatteryStatus-Logic and Buzzer Warning Functionality

### DIFF
--- a/src/vehicle.rs
+++ b/src/vehicle.rs
@@ -242,7 +242,8 @@ impl Vehicle {
         self.leds.0.set_level((!r).into());
         self.leds.1.set_level((!y).into());
         self.leds.2.set_level((!g).into());
-        self.buzzer.tick(self.time.0);
+
+        self.buzzer.tick(self.time.0, self.power.battery_status());
 
         // Send/store telemetry
         if let Some(msg) = self.next_usb_telem() {


### PR DESCRIPTION
added BatteryStatus-Logic to the PowerMonitor: if battery_voltage is below 5000mV no battery is attached, if battery_voltage is higher than 7000mV it is considered HIGH (in between it is considered LOW)

revamped parts of buzzer logic: warning tones are now also melodies instead of a single tone, current melody can be overridden by a warning, buzzer signals repeatedly when BateryStatus is LOW and signals once on startup if no battery is attached, due to the changes set_warning_tone() is obsolete now / doesn't work anymore
